### PR TITLE
make it possible to override names

### DIFF
--- a/cronner.py
+++ b/cronner.py
@@ -22,20 +22,21 @@ class Cronner:
         self._template = template
         self._template_joiner = template_joiner
 
-    def register(self, schedule, template_vars=None):
+    def register(self, schedule, name=None, template_vars=None):
         if template_vars is not None:
             template_vars = dict(template_vars, schedule=schedule)
         else:
             template_vars =  {'schedule': schedule}
         def wrapper(fn):
+            fn_name = name if name is not None else fn.__name__
             fn_cfg = {
                 '_fn': fn,
                 'template_vars': template_vars
             }
-            if fn.__name__ in self._registry and self._registry[fn.__name__] != fn_cfg:
+            if fn_name in self._registry and self._registry[fn_name] != fn_cfg:
                 raise Exception('Function %s and %s have the same name %s' % (
-                        fn, self._registry[fn.__name__]['_fn'], fn.__name))
-            self._registry[fn.__name__] = fn_cfg
+                        fn, self._registry[fn_name]['_fn'], fn_name))
+            self._registry[fn_name] = fn_cfg
             return fn
         return wrapper
 

--- a/test_cronner.py
+++ b/test_cronner.py
@@ -35,6 +35,15 @@ class TestCronner(unittest.TestCase):
         cronner.run('fn')
         self.assertEqual(state, {'a': 1})
 
+    def test_run_different_name(self):
+        state = {}
+        cronner = Cronner()
+        @cronner.register('* * * * *', name='foo')
+        def fn():
+            state['a'] = 2
+        cronner.run('foo')
+        self.assertEqual(state, {'a': 2})
+
     def test_run_with_args(self):
         state = {}
         cronner = Cronner()
@@ -175,3 +184,8 @@ class TestCronner(unittest.TestCase):
         cronner.register('* * * * *')(f1)  # Can register the same function again
         # However, it should fail if we try to register another function with the same name
         self.assertRaises(Exception, lambda: cronner.register('* * * * *')(f2))
+
+        # Let's do it with the name arg as well
+        cronner.register('* * * * *', name='g')(f2)
+        cronner.register('* * * * *', name='g')(f2)
+        self.assertRaises(Exception, lambda: cronner.register('* * * * *', name='g')(f1))


### PR DESCRIPTION
Need this for Kubernetes since it doesn't allow underscores.