### PR TITLE
Make cronner more generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/cronner.py
+++ b/cronner.py
@@ -31,7 +31,7 @@ class Cronner:
         else:
             template_vars =  {'schedule': schedule}
         def wrapper(fn):
-            fn_name = fn.__name__
+            fn_name = '{}.{}'.format(fn.__module__, fn.__name__)
             fn_cfg = {
                 '_fn': fn,
                 'template_vars': template_vars

--- a/cronner.py
+++ b/cronner.py
@@ -25,13 +25,13 @@ class Cronner:
     def configure(self, serializer=_default_serializer):
         self._serializer = serializer
 
-    def register(self, schedule, name=None, template_vars=None):
+    def register(self, schedule, template_vars=None):
         if template_vars is not None:
             template_vars = dict(template_vars, schedule=schedule)
         else:
             template_vars =  {'schedule': schedule}
         def wrapper(fn):
-            fn_name = name if name is not None else fn.__name__
+            fn_name = fn.__name__
             fn_cfg = {
                 '_fn': fn,
                 'template_vars': template_vars

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='cronner',
-    version='0.6.6',
+    version='0.7.0',
     description='Easily schedule python functions to be run under the cron daemon.',
     py_modules=['cronner'],
     test_suite='test_cronner',

--- a/test_cronner.py
+++ b/test_cronner.py
@@ -35,15 +35,6 @@ class TestCronner(unittest.TestCase):
         cronner.run('fn')
         self.assertEqual(state, {'a': 1})
 
-    def test_run_different_name(self):
-        state = {}
-        cronner = Cronner()
-        @cronner.register('* * * * *', name='foo')
-        def fn():
-            state['a'] = 2
-        cronner.run('foo')
-        self.assertEqual(state, {'a': 2})
-
     def test_run_with_args(self):
         state = {}
         cronner = Cronner()
@@ -172,17 +163,3 @@ class TestCronner(unittest.TestCase):
         cronner.register('* * * * *')(f1)  # Can register the same function again
         # However, it should fail if we try to register another function with the same name
         self.assertRaises(Exception, lambda: cronner.register('* * * * *')(f2))
-
-        # Let's do it with the name arg as well
-        cronner.register('* * * * *', name='g')(f2)
-        cronner.register('* * * * *', name='g')(f2)
-        self.assertRaises(Exception, lambda: cronner.register('* * * * *', name='g')(f1))
-
-    def test_explicit_name(self):
-        cronner = Cronner()
-        cronner.configure(serializer=lambda es: '\n'.join(e['fn_name'] for e in es))
-        @cronner.register('* * * * *', name='g')
-        def fn():
-            pass
-        with self.captureOutput(assert_stdout='g\n'):
-            cronner.main(['gen-cfg'])


### PR DESCRIPTION
* allows custom serialization to better support output formats that are not crontab
* uses fully qualified names for functions to avoid name collisions across modules
* remove explicit support for custom function names